### PR TITLE
Fixes #357 For real this time - bad property check

### DIFF
--- a/src/heltour.ts
+++ b/src/heltour.ts
@@ -149,10 +149,10 @@ export const PairingsDecoder: Decoder<Pairing[]> = oneOf(
 
 export type Pairing = IndividualPairing | TeamPairing
 export function isIndividualPairing(obj: Pairing): obj is IndividualPairing {
-    return !obj.hasOwnProperty('white_team')
+    return !obj.hasOwnProperty('whiteTeam')
 }
 export function isTeamPairing(obj: Pairing): obj is TeamPairing {
-    return obj.hasOwnProperty('white_team')
+    return obj.hasOwnProperty('whiteTeam')
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
These functions exist but were unused before my (relatively new) code to detect alts was added. white_team is the property on the response object from Heltour, but whiteTeam is how it should exist on the TeamPairing object